### PR TITLE
Set sux submodule to track the update_build_old_commit branch of my fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "external/sux"]
 	path = external/sux
-	url = https://github.com/vigna/sux.git
+	url = https://github.com/rvarki/sux
+	branch = update_build_old_commit
 [submodule "external/sdsl-lite"]
 	path = external/sdsl-lite
 	url = https://github.com/simongog/sdsl-lite.git


### PR DESCRIPTION
sux dependency of ShapedSLP did not build with gcc >9.3. I added an include <utility> statement to one of the sux files to fix the issue.